### PR TITLE
MySQL.pm: use relative path instead of absolute

### DIFF
--- a/MySQL.pm
+++ b/MySQL.pm
@@ -1,7 +1,7 @@
 package Collectd::Plugin::MySQL;
 use Collectd qw(:all);
 use DBD::mysql;
-require '/usr/lib/collectd/Collectd/Plugins/InnoDBParser.pm';
+require InnoDBParser;
 
 =head1 NAME
 


### PR DESCRIPTION
Hi Mark

Thank you for the great plugins. Can we drop the absolute path in MySQL.pm so I can install them in /opt?

Cheers'
Hannes
